### PR TITLE
C-API calls to qpdf_get_root and qpdf_get_trailer before qpdf_read

### DIFF
--- a/libqpdf/qpdf-c.cc
+++ b/libqpdf/qpdf-c.cc
@@ -855,14 +855,40 @@ void qpdf_oh_release_all(qpdf_data qpdf)
 
 qpdf_oh qpdf_get_trailer(qpdf_data qpdf)
 {
-    QTC::TC("qpdf", "qpdf-c called qpdf_get_trailer");
-    return new_object(qpdf, qpdf->qpdf->getTrailer());
+    qpdf_oh oh = qpdf_get_root(qpdf);
+    if (qpdf_oh_is_null(qpdf, oh))
+    {
+        QTC::TC("qpdf", "qpdf-c called qpdf_get_trailer uninit");
+        return oh;
+    }
+    else{
+        QTC::TC("qpdf", "qpdf-c called qpdf_get_trailer");
+        qpdf_oh_release(qpdf, oh);
+        return new_object(qpdf, qpdf->qpdf->getTrailer());
+    }
 }
 
 qpdf_oh qpdf_get_root(qpdf_data qpdf)
 {
+    qpdf_oh oh;
+    try
+    {
+        oh = new_object(qpdf, qpdf->qpdf->getRoot());
+    }
+    catch (std::logic_error& e)
+    {
+        QTC::TC("qpdf", "qpdf-c called qpdf_get_root uninit");
+	    qpdf->warnings.push_back(
+            QPDFExc(
+                qpdf_e_damaged_pdf,
+                "",
+                "C-API",
+                0,
+                "attempt to retrieve trailer or root before pdf has been read"));
+        return qpdf_oh_new_null(qpdf);
+    }
     QTC::TC("qpdf", "qpdf-c called qpdf_get_root");
-    return new_object(qpdf, qpdf->qpdf->getRoot());
+    return oh;
 }
 
 static bool

--- a/qpdf/qpdf-ctest.c
+++ b/qpdf/qpdf-ctest.c
@@ -502,10 +502,10 @@ static void test24(char const* infile,
 {
     /* This test case is designed for minimal.pdf. */
     qpdf_read(qpdf, infile, password);
-    qpdf_oh trailer = qpdf_get_trailer(qpdf);
-    /* The library never returns 0 */
-    assert(trailer == 1);
     qpdf_oh root = qpdf_get_root(qpdf);
+    /* The library never returns 0 */
+    assert(root == 1);
+    qpdf_oh trailer = qpdf_get_trailer(qpdf);
     assert(qpdf_oh_get_generation(qpdf, root) == 0);
     qpdf_oh root_from_trailer = qpdf_oh_get_key(qpdf, trailer, "/Root");
     assert(qpdf_oh_get_object_id(qpdf, root) ==
@@ -664,6 +664,23 @@ static void test24(char const* infile,
     qpdf_oh_release_all(qpdf);
     assert(! qpdf_oh_is_null(qpdf, mediabox));
     assert(! qpdf_oh_is_array(qpdf, mediabox));
+
+    /* Check calls to qpdf_get_root and qpdf_get_trailer before
+     * qpdf_data is fully initialised create warnings and return
+     * null objects.
+     */
+    qpdf_data qpdf0 = qpdf_init();
+    qpdf_oh null_oh = qpdf_get_trailer(qpdf0);
+    assert(qpdf_oh_is_null(qpdf0, null_oh));
+    null_oh = qpdf_get_root(qpdf0);
+    assert(qpdf_oh_is_null(qpdf0, null_oh));
+    qpdf_error e = 0;
+    while (qpdf_more_warnings(qpdf0))
+    {
+	    e = qpdf_next_warning(qpdf0);
+	    printf("warning: %s\n", qpdf_get_error_full_text(qpdf0, e));
+    }
+
     /* Make sure something is assigned when we exit so we check that
      * it gets properl freed.
      */

--- a/qpdf/qpdf.testcov
+++ b/qpdf/qpdf.testcov
@@ -459,7 +459,9 @@ qpdf-c invalid object handle 0
 qpdf-c called qpdf_oh_release 0
 qpdf-c called qpdf_oh_release_all 0
 qpdf-c called qpdf_get_trailer 0
+qpdf-c called qpdf_get_trailer uninit 0
 qpdf-c called qpdf_get_root 0
+qpdf-c called qpdf_get_root uninit 0
 qpdf-c called qpdf_oh_is_bool 0
 qpdf-c called qpdf_oh_is_null 0
 qpdf-c called qpdf_oh_is_integer 0

--- a/qpdf/qtest/qpdf/c-object-handles.out
+++ b/qpdf/qtest/qpdf/c-object-handles.out
@@ -7,17 +7,19 @@ item 0: 0 0.00
 item 1: 0 0.00
 item 2: 612 612.00
 item 3: 792 792.00
-warning: minimal.pdf (C API object handle 6): attempted access to unknown/uninitialized object handle
+warning: C-API: attempt to retrieve trailer or root before pdf has been read
+warning: C-API: attempt to retrieve trailer or root before pdf has been read
+warning: minimal.pdf (C API object handle 7): attempted access to unknown/uninitialized object handle
   code: 5
   file: minimal.pdf
   pos : 0
   text: attempted access to unknown/uninitialized object handle
-warning: minimal.pdf (C API object handle 9): attempted access to unknown/uninitialized object handle
+warning: minimal.pdf (C API object handle 10): attempted access to unknown/uninitialized object handle
   code: 5
   file: minimal.pdf
   pos : 0
   text: attempted access to unknown/uninitialized object handle
-warning: minimal.pdf (C API object handle 9): attempted access to unknown/uninitialized object handle
+warning: minimal.pdf (C API object handle 10): attempted access to unknown/uninitialized object handle
   code: 5
   file: minimal.pdf
   pos : 0


### PR DESCRIPTION
Catch std::logic_error on calls before qpdf_data is fully initialised and convert into warnings

@jberkenbilt

Is it ok to add the tests to `test24` or would you prefer me to create a new `test25`?

I have used error code `qpdf_e_damaged_pdf` because `qpdf_e_internal` suggest that there is a bug in QPDF  rather than a programming error in the use of the C-API. Should there be a separate error code for this?

Calling `qpdf->qpdf->getTrailer()` before a successful read does not throw a logic_error, but eventually leads to a segmentation fault. I have not looked into this in detail. One area of concern is the `qpdf->qpdf->getFilename()` in `qpdf_oh_valid_internal` . I will investigate this further.

