### PR TITLE
Analyze 765

### DIFF
--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -399,11 +399,6 @@ class QPDF
     QPDFObjectHandle getObjectByObjGen(QPDFObjGen const&);
     QPDF_DLL
     QPDFObjectHandle getObjectByID(int objid, int generation);
-    // The following overload is for internal use and should not
-    // be required by users of the library. Setting resolve to false will
-    // stop getObject from trying to resolve an unresolved object.
-    QPDF_DLL
-    QPDFObjectHandle getObject(QPDFObjGen const&, bool resolve);
 
     // Replace the object with the given object id with the given
     // object. The object handle passed in must be a direct object,
@@ -880,8 +875,8 @@ class QPDF
     };
     friend class Resolver;
 
-    // ParseGuard class allows QPDFObjectHandle to detect re-entrant
-    // resolution
+    // The ParseGuard class allows QPDFObjectHandle to detect
+    // re-entrant parsing.
     class ParseGuard
     {
         friend class QPDFParser;
@@ -903,6 +898,21 @@ class QPDF
         QPDF* qpdf;
     };
     friend class ParseGuard;
+
+    // The GetUnresolved class allows QPDFParser to create unresolved
+    // indirect objects.
+    class GetUnresolved
+    {
+        friend class QPDFParser;
+
+      private:
+        static QPDFObjectHandle
+        getObjectWithoutResolving(QPDF* qpdf, QPDFObjGen const& og)
+        {
+            return qpdf->getObjectWithoutResolving(og);
+        }
+    };
+    friend class GetUnresolved;
 
     // Pipe class is restricted to QPDF_Stream
     class Pipe
@@ -1179,6 +1189,7 @@ class QPDF
         std::shared_ptr<QPDFObject> const& object,
         qpdf_offset_t end_before_space,
         qpdf_offset_t end_after_space);
+    QPDFObjectHandle getObjectWithoutResolving(QPDFObjGen const&);
 
     // Calls finish() on the pipeline when done but does not delete it
     bool pipeStreamData(

--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -1058,26 +1058,6 @@ class QPDF
         QPDFObjGen og;
     };
 
-    class ResolveRecorder
-    {
-      public:
-        ResolveRecorder(QPDF* qpdf, QPDFObjGen const& og) :
-            qpdf(qpdf),
-            og(og)
-        {
-            qpdf->m->resolving.insert(og);
-        }
-        virtual ~ResolveRecorder()
-        {
-            this->qpdf->m->resolving.erase(og);
-        }
-
-      private:
-        QPDF* qpdf;
-        QPDFObjGen og;
-    };
-    friend class ResolveRecorder;
-
     class JSONReactor: public JSON::Reactor
     {
       public:

--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -1073,6 +1073,25 @@ class QPDF
         QPDFObjGen og;
     };
 
+    class ResolveRecorder
+    {
+      public:
+        ResolveRecorder(QPDF* qpdf, QPDFObjGen const& og) :
+            qpdf(qpdf),
+            iter(qpdf->m->resolving.insert(og).first)
+        {
+        }
+        virtual ~ResolveRecorder()
+        {
+            this->qpdf->m->resolving.erase(iter);
+        }
+
+      private:
+        QPDF* qpdf;
+        std::set<QPDFObjGen>::const_iterator iter;
+    };
+    friend class ResolveRecorder;
+
     class JSONReactor: public JSON::Reactor
     {
       public:

--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -399,6 +399,11 @@ class QPDF
     QPDFObjectHandle getObjectByObjGen(QPDFObjGen const&);
     QPDF_DLL
     QPDFObjectHandle getObjectByID(int objid, int generation);
+    // The following overload is for internal use and should not
+    // be required by users of the library. Setting resolve to false will
+    // stop getObject from trying to resolve an unresolved object.
+    QPDF_DLL
+    QPDFObjectHandle getObject(QPDFObjGen const&, bool resolve);
 
     // Replace the object with the given object id with the given
     // object. The object handle passed in must be a direct object,

--- a/include/qpdf/QPDF.hh
+++ b/include/qpdf/QPDF.hh
@@ -899,21 +899,6 @@ class QPDF
     };
     friend class ParseGuard;
 
-    // The GetUnresolved class allows QPDFParser to create unresolved
-    // indirect objects.
-    class GetUnresolved
-    {
-        friend class QPDFParser;
-
-      private:
-        static QPDFObjectHandle
-        getObjectWithoutResolving(QPDF* qpdf, QPDFObjGen const& og)
-        {
-            return qpdf->getObjectWithoutResolving(og);
-        }
-    };
-    friend class GetUnresolved;
-
     // Pipe class is restricted to QPDF_Stream
     class Pipe
     {
@@ -1208,7 +1193,6 @@ class QPDF
         std::shared_ptr<QPDFObject> const& object,
         qpdf_offset_t end_before_space,
         qpdf_offset_t end_after_space);
-    QPDFObjectHandle getObjectWithoutResolving(QPDFObjGen const&);
 
     // Calls finish() on the pipeline when done but does not delete it
     bool pipeStreamData(

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -2188,33 +2188,43 @@ QPDF::reserveStream(QPDFObjGen const& og)
 }
 
 QPDFObjectHandle
-QPDF::getObject(QPDFObjGen const& og)
+QPDF::getObject(QPDFObjGen const& og, bool do_resolve)
 {
     if (!og.isIndirect()) {
         return QPDFObjectHandle::newNull();
     }
-    if (!isCached(og)) {
+    if (do_resolve) {
+        if (isUnresolved(og)) {
+            resolve(og);
+        }
+    } else if (!isCached(og)) {
         m->obj_cache[og] = ObjCache(QPDF_Unresolved::create(this, og), -1, -1);
     }
     return newIndirect(og, m->obj_cache[og].object);
 }
 
 QPDFObjectHandle
+QPDF::getObject(QPDFObjGen const& og)
+{
+    return getObject(og, true);
+}
+
+QPDFObjectHandle
 QPDF::getObject(int objid, int generation)
 {
-    return getObject(QPDFObjGen(objid, generation));
+    return getObject(QPDFObjGen(objid, generation), true);
 }
 
 QPDFObjectHandle
 QPDF::getObjectByObjGen(QPDFObjGen const& og)
 {
-    return getObject(og);
+    return getObject(og, true);
 }
 
 QPDFObjectHandle
 QPDF::getObjectByID(int objid, int generation)
 {
-    return getObject(QPDFObjGen(objid, generation));
+    return getObject(QPDFObjGen(objid, generation), true);
 }
 
 void

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -1945,14 +1945,11 @@ QPDF::resolve(QPDFObjGen const& og)
     if (!isUnresolved(og)) {
         return;
     }
-    // resolve is (and must only be) called with unresolved objects.
 
     if (this->m->resolving.count(og)) {
         // This can happen if an object references itself directly or
         // indirectly in some key that has to be resolved during
         // object parsing, such as stream length.
-        // It could also happen if resolve was called for a previously
-        // resolved object.
         QTC::TC("qpdf", "QPDF recursion loop in resolve");
         warn(
             qpdf_e_damaged_pdf,
@@ -1962,7 +1959,7 @@ QPDF::resolve(QPDFObjGen const& og)
         updateCache(og, QPDF_Null::create(), -1, -1);
         return;
     }
-    this->m->resolving.insert(og);
+    ResolveRecorder rr(this, og);
 
     if (m->xref_table.count(og) != 0) {
         QPDFXRefEntry const& entry = this->m->xref_table[og];

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -1781,9 +1781,8 @@ QPDF::readObjectAtOffset(
         // not triggered by an xref lookup.
         check_og = false;
         try_recovery = false;
-    } else {
-        setLastObjectDescription(description, exp_og);
     }
+    setLastObjectDescription(description, exp_og);
 
     if (!this->m->attempt_recovery) {
         try_recovery = false;
@@ -2189,16 +2188,6 @@ QPDF::reserveStream(QPDFObjGen const& og)
 
 QPDFObjectHandle
 QPDF::getObject(QPDFObjGen const& og)
-{
-    if (!og.isIndirect()) {
-        return QPDFObjectHandle::newNull();
-    }
-    resolve(og);
-    return newIndirect(og, m->obj_cache[og].object);
-}
-
-QPDFObjectHandle
-QPDF::getObjectWithoutResolving(QPDFObjGen const& og)
 {
     if (!isCached(og)) {
         m->obj_cache[og] = ObjCache(QPDF_Unresolved::create(this, og), -1, -1);

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -1942,6 +1942,9 @@ QPDF::readObjectAtOffset(
 void
 QPDF::resolve(QPDFObjGen const& og)
 {
+    if (!isUnresolved(og)) {
+        throw std::logic_error("resolve called on resolved object");
+    }
     // resolve is (and must only be) called with unresolved objects.
 
     if (this->m->resolving.count(og)) {

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -1943,7 +1943,7 @@ void
 QPDF::resolve(QPDFObjGen const& og)
 {
     if (!isUnresolved(og)) {
-        throw std::logic_error("resolve called on resolved object");
+        return;
     }
     // resolve is (and must only be) called with unresolved objects.
 
@@ -2196,9 +2196,7 @@ QPDF::getObject(QPDFObjGen const& og)
     if (!og.isIndirect()) {
         return QPDFObjectHandle::newNull();
     }
-    if (isUnresolved(og)) {
-        resolve(og);
-    }
+    resolve(og);
     return newIndirect(og, m->obj_cache[og].object);
 }
 
@@ -2561,14 +2559,10 @@ QPDF::swapObjects(int objid1, int generation1, int objid2, int generation2)
 void
 QPDF::swapObjects(QPDFObjGen const& og1, QPDFObjGen const& og2)
 {
-    // Force objects to be loaded into cache; then swap them in the
-    // cache.
-    if (isUnresolved(og1)) {
-        resolve(og1);
-    }
-    if (isUnresolved(og2)) {
-        resolve(og2);
-    }
+    // Force objects to be read from the input source if needed, then
+    // swap them in the cache.
+    resolve(og1);
+    resolve(og2);
     m->obj_cache[og1].object->swapWith(m->obj_cache[og2].object);
 }
 

--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -2188,43 +2188,42 @@ QPDF::reserveStream(QPDFObjGen const& og)
 }
 
 QPDFObjectHandle
-QPDF::getObject(QPDFObjGen const& og, bool do_resolve)
+QPDF::getObject(QPDFObjGen const& og)
 {
     if (!og.isIndirect()) {
         return QPDFObjectHandle::newNull();
     }
-    if (do_resolve) {
-        if (isUnresolved(og)) {
-            resolve(og);
-        }
-    } else if (!isCached(og)) {
+    if (isUnresolved(og)) {
+        resolve(og);
+    }
+    return newIndirect(og, m->obj_cache[og].object);
+}
+
+QPDFObjectHandle
+QPDF::getObjectWithoutResolving(QPDFObjGen const& og)
+{
+    if (!isCached(og)) {
         m->obj_cache[og] = ObjCache(QPDF_Unresolved::create(this, og), -1, -1);
     }
     return newIndirect(og, m->obj_cache[og].object);
 }
 
 QPDFObjectHandle
-QPDF::getObject(QPDFObjGen const& og)
-{
-    return getObject(og, true);
-}
-
-QPDFObjectHandle
 QPDF::getObject(int objid, int generation)
 {
-    return getObject(QPDFObjGen(objid, generation), true);
+    return getObject(QPDFObjGen(objid, generation));
 }
 
 QPDFObjectHandle
 QPDF::getObjectByObjGen(QPDFObjGen const& og)
 {
-    return getObject(og, true);
+    return getObject(og);
 }
 
 QPDFObjectHandle
 QPDF::getObjectByID(int objid, int generation)
 {
-    return getObject(QPDFObjGen(objid, generation), true);
+    return getObject(QPDFObjGen(objid, generation));
 }
 
 void

--- a/libqpdf/QPDFParser.cc
+++ b/libqpdf/QPDFParser.cc
@@ -190,7 +190,8 @@ QPDFParser::parse(bool& empty, bool content_stream)
                         olist.at(size - 2).getIntValueAsInt(),
                         olist.back().getIntValueAsInt());
                     if (ref_og.isIndirect()) {
-                        object = context->getObject(ref_og, false);
+                        object = QPDF::GetUnresolved::getObjectWithoutResolving(
+                            context, ref_og);
                         indirect_ref = true;
                     } else {
                         QTC::TC("qpdf", "QPDFParser indirect with 0 objid");

--- a/libqpdf/QPDFParser.cc
+++ b/libqpdf/QPDFParser.cc
@@ -190,8 +190,7 @@ QPDFParser::parse(bool& empty, bool content_stream)
                         olist.at(size - 2).getIntValueAsInt(),
                         olist.back().getIntValueAsInt());
                     if (ref_og.isIndirect()) {
-                        object = QPDF::GetUnresolved::getObjectWithoutResolving(
-                            context, ref_og);
+                        object = context->getObject(ref_og);
                         indirect_ref = true;
                     } else {
                         QTC::TC("qpdf", "QPDFParser indirect with 0 objid");

--- a/libqpdf/QPDFParser.cc
+++ b/libqpdf/QPDFParser.cc
@@ -190,7 +190,7 @@ QPDFParser::parse(bool& empty, bool content_stream)
                         olist.at(size - 2).getIntValueAsInt(),
                         olist.back().getIntValueAsInt());
                     if (ref_og.isIndirect()) {
-                        object = context->getObject(ref_og);
+                        object = context->getObject(ref_og, false);
                         indirect_ref = true;
                     } else {
                         QTC::TC("qpdf", "QPDFParser indirect with 0 objid");

--- a/qpdf/qtest/qpdf/issue-143.out
+++ b/qpdf/qtest/qpdf/issue-143.out
@@ -14,5 +14,6 @@ WARNING: issue-143.pdf (object 1 0, offset 21): stream dictionary lacks /Length 
 WARNING: issue-143.pdf (object 1 0, offset 84): attempting to recover stream length
 WARNING: issue-143.pdf (object 1 0, offset 84): recovered stream length: 606
 WARNING: issue-143.pdf object stream 1 (object 2 0, offset 33): expected dictionary key but found non-name object; inserting key /QPDFFake1
+WARNING: issue-143.pdf: object 0/0 has unexpected xref entry type
 WARNING: issue-143.pdf (object 2 0, offset 84): supposed object stream 12336 is not a stream
 qpdf: operation succeeded with warnings; resulting file may have some problems

--- a/qpdf/qtest/qpdf/obj0-check.out
+++ b/qpdf/qtest/qpdf/obj0-check.out
@@ -5,4 +5,5 @@ checking obj0.pdf
 PDF Version: 1.3
 File is not encrypted
 File is not linearized
+WARNING: obj0.pdf (offset 15): object with ID 0
 qpdf: operation succeeded with warnings


### PR DESCRIPTION
@m-holger Just sharing "privately" with you my step-by-step analysis of #765. I spent way longer on this than I should have, but our SSO system was out at work this morning, and I allowed myself to fall into the rabbit hole.

The performance test results are not significant, but they trend toward slight improvement from my change for complex files for memory and time, though nothing significant. I would justify this change with performance, but I think the result of my analysis led to a couple of things worth keeping. Below are the excerpts of the timings on pdf-spec-1-100.pdf. The first block is before this change. The second block is #765, and the third block is my change.

```
4.1476  342.2984  pdf-spec-1-100.pdf
3.9137  349.8603  pdf-spec-1-100.pdf
3.2083  329.4189  pdf-spec-1-100.pdf
0.2266   17.3411  pdf-spec-1-100.pdf
0.2152   17.3735  pdf-spec-1-100.pdf
5.9626  375.0891  pdf-spec-1-100.pdf
4.2015  349.2624  pdf-spec-1-100.pdf
3.0925  310.1621  pdf-spec-1-100.pdf

4.1860  349.5214  pdf-spec-1-100.pdf
4.1465  350.2624  pdf-spec-1-100.pdf
3.1834  329.8240  pdf-spec-1-100.pdf
0.2096   17.3460  pdf-spec-1-100.pdf
0.2092   17.3466  pdf-spec-1-100.pdf
6.0208  375.3598  pdf-spec-1-100.pdf
4.1924  349.5242  pdf-spec-1-100.pdf
3.1235  310.3164  pdf-spec-1-100.pdf

4.1322  342.2984  pdf-spec-1-100.pdf
3.9063  349.8603  pdf-spec-1-100.pdf
3.1553  329.4189  pdf-spec-1-100.pdf
0.2105   17.3411  pdf-spec-1-100.pdf
0.2149   17.3735  pdf-spec-1-100.pdf
5.9871  375.0891  pdf-spec-1-100.pdf
4.1727  349.2624  pdf-spec-1-100.pdf
3.1165  310.1621  pdf-spec-1-100.pdf
```

Not intended for merge; just FYI. Close at will.