### PR TITLE
Prevent destruction of shared null objects

### DIFF
--- a/libqpdf/QPDF.cc
+++ b/libqpdf/QPDF.cc
@@ -247,10 +247,11 @@ QPDF::~QPDF()
     // but we'll explicitly clear the xref table anyway just to
     // prevent any possibility of resolve() succeeding.
     this->m->xref_table.clear();
-    auto null_obj = QPDF_Null::create();
     for (auto const& iter: this->m->obj_cache) {
         iter.second.object->disconnect();
-        iter.second.object->destroy();
+        if (iter.second.object->getTypeCode() != ::ot_null) {
+            iter.second.object->destroy();
+        }
     }
 }
 


### PR DESCRIPTION
#863 uses a single null object for nulls that were previously implicit. In certain circumstances this shared null object gets destroyed (i.e changed to a QPDF_Destroyed object) when a QPDF object is destroyed.

Modify the QPDF destructor so that null objects get disconnected from the dying QPDF object but not destroyed to prevent this from happening.