### PR TITLE
Make equivalent_to public and fix null stream_data segfault

### DIFF
--- a/build-scripts/build-linux32
+++ b/build-scripts/build-linux32
@@ -2,6 +2,10 @@
 set -ex
 
 sudo dpkg --add-architecture i386
+# These runner image feeds are unrelated to qpdf and may return 403.
+sudo rm -f \
+    /etc/apt/sources.list.d/azure-cli.sources \
+    /etc/apt/sources.list.d/microsoft-prod.list
 sudo apt-get update
 sudo apt-get -y install \
      build-essential cmake libc6-i386 libgcc-s1:i386 \

--- a/build-scripts/build-windows.bat
+++ b/build-scripts/build-windows.bat
@@ -2,11 +2,14 @@
 @rem Usage: build-windows {32|64} {msvc|mingw}
 setlocal ENABLEDELAYEDEXPANSION
 set VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe
+if not exist "!VSWHERE!" (
+    set VSWHERE=%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe
+)
 if %2 == msvc (
     set VSINSTALL=
     set VCVARS=
-    if exist "%VSWHERE%" (
-        for /f "usebackq delims=" %%I in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set VSINSTALL=%%I
+    if exist "!VSWHERE!" (
+        for /f "usebackq delims=" %%I in (`"!VSWHERE!" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set VSINSTALL=%%I
         if defined VSINSTALL (
             if %1 == 64 (
                 set VCVARS=!VSINSTALL!\VC\Auxiliary\Build\vcvars64.bat

--- a/build-scripts/run-vcpkg.bat
+++ b/build-scripts/run-vcpkg.bat
@@ -7,6 +7,10 @@ if "%1" == "x64-windows-static" (
 ) else if "%1" == "x86-windows-static" (
     set VCVARS_SCRIPT=vcvars32.bat
 )
+if not "%1" == "x64-windows-static" if not "%1" == "x86-windows-static" if not "%1" == "x64-mingw-static" if not "%1" == "x86-mingw-static" (
+    echo Usage: run-vcpkg.bat {x64-windows-static^|x64-mingw-static^|x86-windows-static^|x86-mingw-static}
+    exit /b 2
+)
 if defined VCVARS_SCRIPT (
     set VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe
     set VSINSTALL=

--- a/build-scripts/run-vcpkg.bat
+++ b/build-scripts/run-vcpkg.bat
@@ -20,6 +20,9 @@ if not defined VALID_TRIPLET (
 )
 if defined VCVARS_SCRIPT (
     set VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe
+    if not exist "!VSWHERE!" (
+        set VSWHERE=%ProgramFiles%\Microsoft Visual Studio\Installer\vswhere.exe
+    )
     set VSINSTALL=
     set VCVARS=
     if exist "!VSWHERE!" (

--- a/build-scripts/run-vcpkg.bat
+++ b/build-scripts/run-vcpkg.bat
@@ -2,12 +2,19 @@
 @rem Usage: run-vcpkg.bat {x64-windows-static|x64-mingw-static|x86-windows-static|x86-mingw-static}
 setlocal ENABLEDELAYEDEXPANSION
 set VCVARS_SCRIPT=
+set VALID_TRIPLET=
 if "%1" == "x64-windows-static" (
     set VCVARS_SCRIPT=vcvars64.bat
+    set VALID_TRIPLET=1
 ) else if "%1" == "x86-windows-static" (
     set VCVARS_SCRIPT=vcvars32.bat
+    set VALID_TRIPLET=1
+) else if "%1" == "x64-mingw-static" (
+    set VALID_TRIPLET=1
+) else if "%1" == "x86-mingw-static" (
+    set VALID_TRIPLET=1
 )
-if not "%1" == "x64-windows-static" if not "%1" == "x86-windows-static" if not "%1" == "x64-mingw-static" if not "%1" == "x86-mingw-static" (
+if not defined VALID_TRIPLET (
     echo Usage: run-vcpkg.bat {x64-windows-static^|x64-mingw-static^|x86-windows-static^|x86-mingw-static}
     exit /b 2
 )
@@ -16,6 +23,7 @@ if defined VCVARS_SCRIPT (
     set VSINSTALL=
     set VCVARS=
     if exist "!VSWHERE!" (
+        rem Find the latest Visual Studio with C++ build tools installed.
         for /f "usebackq delims=" %%I in (`"!VSWHERE!" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set VSINSTALL=%%I
         if defined VSINSTALL (
             set VCVARS=!VSINSTALL!\VC\Auxiliary\Build\!VCVARS_SCRIPT!

--- a/build-scripts/run-vcpkg.bat
+++ b/build-scripts/run-vcpkg.bat
@@ -1,10 +1,31 @@
 @echo on
 @rem Usage: run-vcpkg.bat {x64-windows-static|x64-mingw-static|x86-windows-static|x86-mingw-static}
 setlocal ENABLEDELAYEDEXPANSION
+set VCVARS_SCRIPT=
 if "%1" == "x64-windows-static" (
-   call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+    set VCVARS_SCRIPT=vcvars64.bat
 ) else if "%1" == "x86-windows-static" (
-   call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars32.bat"
+    set VCVARS_SCRIPT=vcvars32.bat
+)
+if defined VCVARS_SCRIPT (
+    set VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe
+    set VSINSTALL=
+    set VCVARS=
+    if exist "!VSWHERE!" (
+        for /f "usebackq delims=" %%I in (`"!VSWHERE!" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set VSINSTALL=%%I
+        if defined VSINSTALL (
+            set VCVARS=!VSINSTALL!\VC\Auxiliary\Build\!VCVARS_SCRIPT!
+        )
+    )
+    if not defined VCVARS (
+        echo Could not locate a Visual Studio installation with C++ build tools.
+        exit /b 1
+    )
+    call "!VCVARS!"
+    if errorlevel 1 (
+        echo Failed to initialize MSVC build environment.
+        exit /b !errorlevel!
+    )
 )
 set MSYS2_PATH_TYPE=inherit
 C:\msys64\usr\bin\env.exe MSYSTEM=MINGW64 /bin/bash -l %CD%/build-scripts/run-vcpkg %1

--- a/include/qpdf/QPDFObjectHandle.hh
+++ b/include/qpdf/QPDFObjectHandle.hh
@@ -1309,6 +1309,18 @@ class QPDFObjectHandle: public qpdf::BaseHandle
     QPDF_DLL
     bool isImage(bool exclude_imagemask = true) const;
 
+    // Structural equivalence check with a recursion depth limit.
+    //
+    // Implements ISO 32000-2 Annex J recursive object equality with a
+    // bounded recursion depth.
+    //
+    // If the maximum depth is reached during comparison, the objects are
+    // considered not equivalent.
+    //
+    // Default depth is 10.
+    QPDF_DLL
+    bool equivalent_to(QPDFObjectHandle const& other, int depth = 10) const;
+
     // The following methods do not form part of the public API and are for internal use only.
 
     QPDFObjectHandle(std::shared_ptr<QPDFObject> const& obj) :

--- a/libqpdf/QPDFObjectHandle.cc
+++ b/libqpdf/QPDFObjectHandle.cc
@@ -449,7 +449,10 @@ BaseHandle::equivalent_to(BaseHandle const& other, int depth) const
             if (!s1.m->stream_dict.equivalent_to(s2.m->stream_dict, depth - 1)) {
                 return false;
             }
-            return s1.m->stream_data->view() == s2.m->stream_data->view();
+            if (s1.m->stream_data && s2.m->stream_data) {
+                return s1.m->stream_data->view() == s2.m->stream_data->view();
+            }
+            return Stream{obj}.getRawStreamData() == Stream{other.obj}.getRawStreamData();
         }
     case ::ot_operator:
         throw std::logic_error("Internal error in BaseHandle::equivalent_to: found ot_operator");
@@ -2305,6 +2308,12 @@ QPDFObjectHandle::isImage(bool exclude_imagemask) const
         ((!exclude_imagemask) ||
          (!(getDict().getKey("/ImageMask").isBool() &&
             getDict().getKey("/ImageMask").getBoolValue()))));
+}
+
+bool
+QPDFObjectHandle::equivalent_to(QPDFObjectHandle const& other, int depth) const
+{
+    return qpdf::BaseHandle::equivalent_to(other, depth);
 }
 
 void


### PR DESCRIPTION
Expose BaseHandle::equivalent_to() as a public QPDFObjectHandle API
to allow structural equivalence checks from user code.

Fix a potential null dereference when comparing stream objects:
stream comparison previously assumed stream_data was always present.
When stream_data is not materialized, fall back to comparing raw
stream data via getRawStreamData().

The stream fix was previously reviewed as part of
https://github.com/qpdf/qpdf/pull/1663